### PR TITLE
Fix pixel border and Auto Transition (Frames) reveal bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,7 @@
 
 ## Documentation
 
-- Keep README link behavior intentional and consistent. Use standard Markdown links by default, and use HTML anchors with `target="_blank"` and `rel="noopener noreferrer"` only when links should explicitly open in a new tab.
-- Keep README and AGENTS guidance focused on current behavior, active requirements, and durable project decisions. Remove
-  migration-era notes, deprecated-option explanations, old fallback paths, and historical caveats once they no longer
-  affect how someone uses, maintains, deploys, or releases the project. When a state change makes a requirement obsolete,
-  update the affected docs and configuration in that same change.
+- Use `../shared-automation/AGENTS.md` as the source of truth for README and Markdown documentation-style conventions.
 
 ## Auto Transition Timing
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ These local wrappers inherit their reusable implementations from `cyaris/shared-
 inputs, and secrets are documented in the
 [shared-automation workflow reference](https://github.com/cyaris/shared-automation#workflows).
 
+### `.github/workflows/auto-create-dev-pr.yml`
+
+The `Auto-create dev pull request` workflow runs on pushes to `dev`, then calls the
+[shared auto-create-dev-pr workflow](https://github.com/cyaris/shared-automation#githubworkflowsauto-create-dev-pryml)
+to open a pull request from `dev` to `main` when one doesn't already exist. It passes the repository's
+`RELEASE_TOKEN` secret so trusted user or agent-authored pushes to `dev` can open the pull request.
+
+### `.github/workflows/auto-release.yml`
+
+The `Auto release` workflow runs from manual dispatch only and calls the
+[shared auto-release workflow](https://github.com/cyaris/shared-automation#githubworkflowsauto-releaseyml). This
+repository contributes `.github/release-policy.yml` overrides. Release creation or existing-release updates require
+reviewing the generated plan and explicitly enabling publication for an approved run.
+
 ### `.github/workflows/rollup.yml`
 
 The `Rollup` workflow runs on pushes to `dev` and `main` and on manual dispatch, then calls the
@@ -133,13 +147,6 @@ minutes before the GitHub Pages build for `cyaris.github.io`, and on manual disp
 watches `svelte-lib`'s and `fireworks`'s `main` branches and, when either has moved since the last check, dispatches
 this repository's own `Rollup` workflow on `main` so the build picks up the new upstream commit without waiting for a
 push here.
-
-### `.github/workflows/auto-release.yml`
-
-The `Auto release` workflow runs from manual dispatch only and calls the
-[shared auto-release workflow](https://github.com/cyaris/shared-automation#githubworkflowsauto-releaseyml). This
-repository contributes `.github/release-policy.yml` overrides. Release creation or existing-release updates require
-reviewing the generated plan and explicitly enabling publication for an approved run.
 
 ### `.github/workflows/workflow-validation.yml`
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "profile-photo",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "d3-selection": "3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7909,22 +7909,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "postinstall": "linklocal",
     "dev": "vite --host",
     "dev:open": "vite --host --open",
     "build": "vite build",

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -504,7 +504,7 @@
   })
 </script>
 
-<div class="mb-8 flex flex-col items-center">
+<div class="mb-8 flex flex-col items-center overflow-x-clip">
   <div
     class="relative w-fit max-w-md"
     class:non-reactive={isAutoTransition}
@@ -525,7 +525,7 @@
       height={profilePhotoNaturalSize}
       on:load={scheduleRender}
     />
-    <svg class="pointer-events-none absolute left-0 top-0 overflow-hidden" width={displayWidth} height={displayHeight}>
+    <svg class="pointer-events-none absolute left-0 top-0 overflow-visible" width={displayWidth} height={displayHeight}>
       <g bind:this={laserEyeCanvas}></g>
     </svg>
     <canvas

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -504,7 +504,7 @@
   })
 </script>
 
-<div class="mb-8 flex flex-col items-center overflow-x-clip">
+<div class="mb-8 flex flex-col items-center">
   <div
     class="relative w-fit max-w-md"
     class:non-reactive={isAutoTransition}

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -27,6 +27,8 @@
   import profilePhotoSrc from "../static/favicon.png"
   import pixels from "../static/pixels.json"
 
+  export let autoTransitionSetDelay = undefined
+  export let autoTransitionSetDuration = undefined
   export let forcedMode = undefined
   export let showModeSelection = true
   export let transitionPixelRadius = 2
@@ -107,9 +109,6 @@
   let prefersReducedMotion = false
   let renderFrame
   let isDestroyed = false
-
-  export let autoTransitionSetDuration = undefined
-  export let autoTransitionSetDelay = undefined
 
   $: revealedPixelRatio = revealedPixelCount / pixelRecords.length
   $: activeMode = modeItems[sliderValue]?.value ?? modeItems[0].value

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -131,26 +131,40 @@ function getPixelRenderState(pixel, state, geometry, timestamp) {
   return getPixelDisplay(pixel, geometry)
 }
 
-function drawPixel(context, pixel, renderState) {
+function fillPixel(context, pixel, renderState) {
   if (renderState.opacity <= 0) return
 
+  context.globalAlpha = renderState.opacity
+  context.fillStyle = pixel.rgb
+
   if (!renderState.rotation) {
-    context.globalAlpha = renderState.opacity
-    context.fillStyle = pixel.rgb
-    context.lineWidth = renderState.strokeWidth
     context.fillRect(renderState.x, renderState.y, renderState.width, renderState.height)
+
+    return
+  }
+
+  context.save()
+  context.translate(renderState.translateX, renderState.translateY)
+  context.rotate(renderState.rotation)
+  context.fillRect(renderState.x, renderState.y, renderState.width, renderState.height)
+  context.restore()
+}
+
+function strokePixel(context, renderState) {
+  if (renderState.opacity <= 0) return
+
+  context.globalAlpha = renderState.opacity
+  context.lineWidth = renderState.strokeWidth
+
+  if (!renderState.rotation) {
     context.strokeRect(renderState.x, renderState.y, renderState.width, renderState.height)
 
     return
   }
 
   context.save()
-  context.globalAlpha = renderState.opacity
-  context.fillStyle = pixel.rgb
-  context.lineWidth = renderState.strokeWidth
   context.translate(renderState.translateX, renderState.translateY)
   context.rotate(renderState.rotation)
-  context.fillRect(renderState.x, renderState.y, renderState.width, renderState.height)
   context.strokeRect(renderState.x, renderState.y, renderState.width, renderState.height)
   context.restore()
 }
@@ -356,13 +370,17 @@ export function drawPixelCanvas({ canvas, geometry, pixels, states, timestamp })
   let { context } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
   if (!context) return false
 
+  let pixelRenderStates = pixels.map(pixel => ({
+    pixel,
+    renderState: getPixelRenderState(pixel, states[pixel.index], geometry, timestamp)
+  }))
+
   context.clearRect(0, 0, canvasWidth, canvasHeight)
   context.save()
   context.translate(overflow, overflow)
   context.strokeStyle = "white"
-  pixels.forEach(pixel =>
-    drawPixel(context, pixel, getPixelRenderState(pixel, states[pixel.index], geometry, timestamp))
-  )
+  pixelRenderStates.forEach(({ pixel, renderState }) => fillPixel(context, pixel, renderState))
+  pixelRenderStates.forEach(({ renderState }) => strokePixel(context, renderState))
   context.restore()
 
   return compactFinishedStates(states, timestamp)
@@ -398,6 +416,21 @@ function createHorizontalSlice({ cornerIndex, maxX, minX, y }, grid) {
     ),
     cornerIndex
   }
+}
+
+function createFilledSlices({ cornerIndex, maxX, maxY, minX, minY }, grid) {
+  let sweepByColumn = maxX - minX >= maxY - minY
+  let reverse = sweepByColumn ? cornerIndex == 1 || cornerIndex == 2 : cornerIndex == 2 || cornerIndex == 3
+
+  let slices = sweepByColumn
+    ? Array.from({ length: maxX - minX + 1 }, (_, index) => createVerticalSlice({ maxY, minY, x: minX + index }, grid))
+    : Array.from({ length: maxY - minY + 1 }, (_, index) =>
+        createHorizontalSlice({ maxX, minX, y: minY + index }, grid)
+      )
+
+  if (reverse) slices.reverse()
+
+  return slices.filter(slice => slice?.indexes?.length)
 }
 
 function createFrameSlices({ cornerIndex, maxX, maxY, minX, minY, ringWidth }, grid) {
@@ -450,13 +483,16 @@ export function createAutoTransitionFramePaths({ cellPixelIndexes, columnCount, 
     let maxY = rowCount - 1 - inset
     let remainingWidth = maxX - minX + 1
     let remainingHeight = maxY - minY + 1
-    let ringWidth = Math.min(baseRingWidth, Math.ceil(Math.min(remainingWidth, remainingHeight) / 2))
+    let ringWidth = Math.min(baseRingWidth, Math.floor(Math.min(remainingWidth, remainingHeight) / 2))
     let pathCornerIndex = index % 2 ? (cornerIndex + 2) % 4 : cornerIndex
 
     paths.push({
       activeIndexes: [],
       activeSliceIndex: undefined,
-      slices: createFrameSlices({ cornerIndex: pathCornerIndex, maxX, maxY, minX, minY, ringWidth }, grid)
+      slices:
+        ringWidth < baseRingWidth
+          ? createFilledSlices({ cornerIndex: pathCornerIndex, maxX, maxY, minX, minY }, grid)
+          : createFrameSlices({ cornerIndex: pathCornerIndex, maxX, maxY, minX, minY, ringWidth }, grid)
     })
   }
 

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -433,29 +433,61 @@ function createFilledSlices({ cornerIndex, maxX, maxY, minX, minY }, grid) {
   return slices.filter(slice => slice?.indexes?.length)
 }
 
+function createCornerSlices({ cornerIndex, mapPoint, ringWidth }, grid) {
+  let maxDiagonal = (ringWidth - 1) * 2
+  let slices = []
+
+  for (let diagonal = 0; diagonal <= maxDiagonal; diagonal += 1) {
+    let iStart = Math.max(0, diagonal - (ringWidth - 1))
+    let iEnd = Math.min(diagonal, ringWidth - 1)
+    let points = Array.from({ length: iEnd - iStart + 1 }, (_, index) =>
+      mapPoint(iStart + index, diagonal - iStart - index)
+    )
+    let slice = createSlice(points, grid)
+
+    if (slice) slices.push({ ...slice, cornerIndex: diagonal == 0 ? cornerIndex : undefined })
+  }
+
+  return slices
+}
+
 function createFrameSlices({ cornerIndex, maxX, maxY, minX, minY, ringWidth }, grid) {
   let slices = []
 
-  for (let x = minX; x <= maxX; x += 1) {
+  for (let x = minX; x <= maxX - ringWidth; x += 1) {
     slices.push(
-      createVerticalSlice(
-        { cornerIndex: x == minX ? 0 : x == maxX ? 1 : undefined, maxY: minY + ringWidth - 1, minY, x },
-        grid
-      )
+      createVerticalSlice({ cornerIndex: x == minX ? 0 : undefined, maxY: minY + ringWidth - 1, minY, x }, grid)
     )
   }
 
-  for (let y = minY + ringWidth; y <= maxY; y += 1) {
-    slices.push(
-      createHorizontalSlice({ cornerIndex: y == maxY ? 2 : undefined, maxX, minX: maxX - ringWidth + 1, y }, grid)
+  slices.push(
+    ...createCornerSlices(
+      { cornerIndex: 1, mapPoint: (i, j) => ({ x: maxX - ringWidth + 1 + i, y: minY + j }), ringWidth },
+      grid
     )
+  )
+
+  for (let y = minY + ringWidth; y <= maxY - ringWidth; y += 1) {
+    slices.push(createHorizontalSlice({ maxX, minX: maxX - ringWidth + 1, y }, grid))
   }
 
-  for (let x = maxX - ringWidth; x >= minX; x -= 1) {
-    slices.push(
-      createVerticalSlice({ cornerIndex: x == minX ? 3 : undefined, maxY, minY: maxY - ringWidth + 1, x }, grid)
+  slices.push(
+    ...createCornerSlices(
+      { cornerIndex: 2, mapPoint: (i, j) => ({ x: maxX - i, y: maxY - ringWidth + 1 + j }), ringWidth },
+      grid
     )
+  )
+
+  for (let x = maxX - ringWidth; x >= minX + ringWidth; x -= 1) {
+    slices.push(createVerticalSlice({ maxY, minY: maxY - ringWidth + 1, x }, grid))
   }
+
+  slices.push(
+    ...createCornerSlices(
+      { cornerIndex: 3, mapPoint: (i, j) => ({ x: minX + ringWidth - 1 - i, y: maxY - j }), ringWidth },
+      grid
+    )
+  )
 
   for (let y = maxY - ringWidth; y >= minY + ringWidth; y -= 1) {
     slices.push(createHorizontalSlice({ maxX: minX + ringWidth - 1, minX, y }, grid))

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,3 +7,9 @@
 </script>
 
 <slot />
+
+<style>
+  :global(body) {
+    overflow-x: clip;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Fixed pixel canvas rendering so a pixel's border stroke can no longer be partially erased by an overlapping neighbor (most visible on freshly revealed pixels, which could show missing strokes on certain sides).
- Fixed a bug in Auto Transition (Frames) where the sweep's final ring, when it ran out of room to keep its full ring thickness, could re-reveal already-swept pixels instead of cleanly transposing to sweep the remaining region, and in some grid sizes could leave a pixel uncovered entirely.
- Let laser vision extend beyond the portrait, then contained it back to the viewport so it doesn't overflow the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved profile-photo transition animations, including smoother pixel rendering, rotation, opacity, and ring effects.
  * Updated laser-eye visuals to display effects beyond their original bounds.
  * Improved animation timing configuration.
  * Prevented unwanted horizontal scrolling across the application.

* **Documentation**
  * Added documentation for the automatic development-to-main pull request workflow.
  * Updated workflow documentation organization and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->