### PR TITLE
Migrate laser-eye to Canvas and consolidate animation loops onto svelte-lib

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,9 +26,7 @@
     "esbuild": "^0.25.2"
   },
   "dependencies": {
-    "d3-selection": "3",
     "d3-timer": "3",
-    "d3-transition": "3",
     "fireworks": "file:../../fireworks",
     "linklocal": "^2.8.2",
     "svelte": "4.2.20",

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -1,12 +1,12 @@
 <script>
-  import "d3-transition"
-
-  import { select } from "d3-selection"
   import { interval } from "d3-timer"
   import { FireworkShow } from "fireworks/components"
   import { onDestroy, onMount } from "svelte"
   import { Loading, ProgressBar, Select, Toggle } from "svelte-lib/components"
+  import { createAnimationLoop } from "svelte-lib/functions"
+  import { getCanvasPointerPoint } from "svelte-lib/functions/canvas"
 
+  import { createLaserEyeBurst, drawLaserEyeCanvas, laserEyeRadiusScale } from "../laserEye.js"
   import {
     activatePixelIndexes,
     advanceAutoTransitionPath,
@@ -97,17 +97,16 @@
   let sliderValue = Math.max(getModeValue(forcedMode), 0)
   let modeSelectValue = modeItems[sliderValue]
   let laserEyesTimer
+  let laserEyeCircles = []
   let laserVisionEnabled = false
   let activePointerId
   let activePointerPixelIndex
   let activePointerTarget
   let activePointerNeighborhoodIndexes = new Set()
-  let autoTransitionFrame
   let autoTransitionPaths = []
   let autoTransitionNextStepTime
   let autoTransitionKey
   let prefersReducedMotion = false
-  let renderFrame
   let isDestroyed = false
 
   $: revealedPixelRatio = revealedPixelCount / pixelRecords.length
@@ -160,24 +159,36 @@
     pixelRowCount
   ].join(":")
   $: isProfileReady = pixelCanvas && laserEyeCanvas && geometry
-
-  function scheduleRender() {
-    if (!isDestroyed && !renderFrame) {
-      renderFrame = requestAnimationFrame(renderPixels)
-    }
-  }
+  $: laserEyeOverflow = displayWidth ? displayWidth * laserEyeRadiusScale : 0
 
   function renderPixels(timestamp) {
-    renderFrame = undefined
+    if (!pixelCanvas || !geometry) return false
 
-    if (!pixelCanvas || !geometry) {
-      return
-    }
-
-    if (drawPixelCanvas({ canvas: pixelCanvas, geometry, pixels: pixelRecords, states: pixelStates, timestamp })) {
-      scheduleRender()
-    }
+    return drawPixelCanvas({ canvas: pixelCanvas, geometry, pixels: pixelRecords, states: pixelStates, timestamp })
   }
+
+  let pixelAnimationLoop = createAnimationLoop(renderPixels)
+
+  function scheduleRender() {
+    if (!isDestroyed) pixelAnimationLoop.start()
+  }
+
+  function laserEyeFrame(timestamp) {
+    let result = drawLaserEyeCanvas({
+      canvas: laserEyeCanvas,
+      circles: laserEyeCircles,
+      height: displayHeight,
+      overflow: laserEyeOverflow,
+      timestamp,
+      width: displayWidth
+    })
+
+    laserEyeCircles = result.circles
+
+    return result.hasActive
+  }
+
+  let laserEyeAnimationLoop = createAnimationLoop(laserEyeFrame)
 
   function revealPixel(index) {
     if (revealedPixels[index]) return
@@ -204,19 +215,10 @@
   }
 
   function getPointerPixelIndex(event) {
-    let bounds = pixelCanvas?.getBoundingClientRect()
-
     return getPixelIndexFromPoint({
       cellPixelIndexes,
       columnCount: pixelColumnCount,
-      point: bounds
-        ? {
-            x: event.clientX - bounds.left - canvasOverflow,
-            y: event.clientY - bounds.top - canvasOverflow,
-            width: displayWidth,
-            height: displayHeight
-          }
-        : undefined,
+      point: getCanvasPointerPoint(pixelCanvas, event, { offsetX: canvasOverflow, offsetY: canvasOverflow }),
       rowCount: pixelRowCount
     })
   }
@@ -329,33 +331,14 @@
     }
   }
 
-  let executeLaserEye = function (i, cxInput, cyInput, radiusBasis) {
-    let circles = select(laserEyeCanvas)
-      .append("circle")
-      .attr("cx", cxInput)
-      .attr("cy", cyInput)
-      .attr("r", 0.25)
-      .style("fill", "transparent")
-      .style("stroke", "#cc0000")
-      .style("stroke-width", 7.5)
-
-    circles
-      .transition()
-      .delay(i * 225 + 500)
-      .duration(3000)
-      .attr("r", radiusBasis * 0.75)
-      .style("stroke-width", 0)
-      .style("stroke-opacity", 0)
-      .on("end", () => circles.remove())
-  }
-
-  let executeLaserEyes = function () {
+  function executeLaserEyes() {
     if (!displayWidth || !displayHeight || !laserEyeCanvas) return
 
-    Array.from({ length: 4 }, (_, index) => index).forEach(i => {
-      executeLaserEye(i, displayWidth * 0.44, displayHeight * 0.5, displayWidth)
-      executeLaserEye(i, displayWidth * 0.6125, displayHeight * 0.49, displayWidth)
-    })
+    laserEyeCircles = [
+      ...laserEyeCircles,
+      ...createLaserEyeBurst({ displayHeight, displayWidth, now: performance.now() })
+    ]
+    laserEyeAnimationLoop.start()
   }
 
   function stopLaserEyes() {
@@ -364,7 +347,19 @@
       laserEyesTimer = undefined
     }
 
-    select(laserEyeCanvas).selectAll("circle").interrupt().remove()
+    laserEyeAnimationLoop.stop()
+    laserEyeCircles = []
+
+    if (laserEyeCanvas) {
+      drawLaserEyeCanvas({
+        canvas: laserEyeCanvas,
+        circles: [],
+        height: displayHeight,
+        overflow: laserEyeOverflow,
+        timestamp: performance.now(),
+        width: displayWidth
+      })
+    }
   }
 
   function handleLaserVisionChange({ detail }) {
@@ -375,21 +370,6 @@
       laserEyesTimer = interval(executeLaserEyes, 3000)
     } else {
       stopLaserEyes()
-    }
-  }
-
-  function stopAutoTransition({ reset = false } = {}) {
-    if (autoTransitionFrame) {
-      cancelAnimationFrame(autoTransitionFrame)
-      autoTransitionFrame = undefined
-    }
-
-    autoTransitionPaths = []
-    autoTransitionNextStepTime = undefined
-    autoTransitionKey = undefined
-
-    if (reset) {
-      resetPixels()
     }
   }
 
@@ -422,11 +402,24 @@
       scheduleRender()
     }
 
-    autoTransitionFrame = requestAnimationFrame(advanceAutoTransition)
+    return true
+  }
+
+  let autoTransitionAnimationLoop = createAnimationLoop(advanceAutoTransition)
+
+  function stopAutoTransition({ reset = false } = {}) {
+    autoTransitionAnimationLoop.stop()
+    autoTransitionPaths = []
+    autoTransitionNextStepTime = undefined
+    autoTransitionKey = undefined
+
+    if (reset) {
+      resetPixels()
+    }
   }
 
   function startAutoTransition(nextAutoTransitionKey) {
-    if (autoTransitionFrame && autoTransitionKey == nextAutoTransitionKey) {
+    if (autoTransitionKey == nextAutoTransitionKey) {
       return
     }
 
@@ -446,7 +439,7 @@
           radius: transitionPixelRadius,
           rowCount: pixelRowCount
         })
-    autoTransitionFrame = requestAnimationFrame(advanceAutoTransition)
+    autoTransitionAnimationLoop.start()
   }
 
   function setModeValue(value) {
@@ -493,10 +486,7 @@
   onDestroy(() => {
     isDestroyed = true
 
-    if (renderFrame) {
-      cancelAnimationFrame(renderFrame)
-    }
-
+    pixelAnimationLoop.stop()
     stopAutoTransition({ reset: true })
     stopLaserEyes()
     releaseActivePointer()
@@ -524,9 +514,15 @@
       height={profilePhotoNaturalSize}
       on:load={scheduleRender}
     />
-    <svg class="pointer-events-none absolute left-0 top-0 overflow-visible" width={displayWidth} height={displayHeight}>
-      <g bind:this={laserEyeCanvas}></g>
-    </svg>
+    <canvas
+      bind:this={laserEyeCanvas}
+      class="pointer-events-none absolute"
+      style:left="{-laserEyeOverflow}px"
+      style:top="{-laserEyeOverflow}px"
+      style:width="{displayWidth + laserEyeOverflow * 2}px"
+      style:height="{displayHeight + laserEyeOverflow * 2}px"
+      aria-hidden="true"
+    ></canvas>
     <canvas
       bind:this={pixelCanvas}
       class="pointer-events-none absolute"
@@ -554,7 +550,7 @@
           />
           <Toggle
             checked={laserVisionEnabled}
-            label="Laser vision"
+            label="Laser Vision"
             wrapperClasses="w-64"
             on:change={handleLaserVisionChange}
           />

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -521,6 +521,7 @@
       style:top="{-laserEyeOverflow}px"
       style:width="{displayWidth + laserEyeOverflow * 2}px"
       style:height="{displayHeight + laserEyeOverflow * 2}px"
+      style:z-index={70}
       aria-hidden="true"
     ></canvas>
     <canvas

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -507,7 +507,7 @@
   <div
     class="relative w-fit max-w-md"
     class:non-reactive={isAutoTransition}
-    style:touch-action="none"
+    style:touch-action="pinch-zoom"
     bind:clientWidth={displayWidth}
     bind:clientHeight={displayHeight}
     on:pointerdown={handlePixelPointerDown}

--- a/frontend/src/lib/laserEye.js
+++ b/frontend/src/lib/laserEye.js
@@ -1,0 +1,73 @@
+import { easeCubicInOut, getEasedProgress } from "svelte-lib/functions"
+import { configureCanvas2D } from "svelte-lib/functions/canvas"
+
+const laserEyeColor = "#cc0000"
+const laserEyeDelayStep = 225
+const laserEyeInitialDelay = 500
+const laserEyeDuration = 3000
+const laserEyeStartRadius = 0.25
+const laserEyeStartStrokeWidth = 7.5
+const laserEyePositions = [
+  { xRatio: 0.44, yRatio: 0.5 },
+  { xRatio: 0.6125, yRatio: 0.49 }
+]
+
+export const laserEyeRadiusScale = 0.75
+
+export function createLaserEyeBurst({ displayHeight, displayWidth, now }) {
+  return Array.from({ length: 4 }, (_, i) => i).flatMap(i =>
+    laserEyePositions.map(({ xRatio, yRatio }) => ({
+      cx: displayWidth * xRatio,
+      cy: displayHeight * yRatio,
+      delay: i * laserEyeDelayStep + laserEyeInitialDelay,
+      radiusBasis: displayWidth,
+      start: now
+    }))
+  )
+}
+
+function getLaserEyeDraw(circle, timestamp) {
+  let progress = getEasedProgress({
+    delay: circle.delay,
+    duration: laserEyeDuration,
+    ease: easeCubicInOut,
+    now: timestamp,
+    start: circle.start
+  })
+
+  return {
+    cx: circle.cx,
+    cy: circle.cy,
+    radius: laserEyeStartRadius + (circle.radiusBasis * laserEyeRadiusScale - laserEyeStartRadius) * progress,
+    strokeOpacity: 1 - progress,
+    strokeWidth: laserEyeStartStrokeWidth * (1 - progress)
+  }
+}
+
+export function drawLaserEyeCanvas({ canvas, circles, height, overflow = 0, timestamp, width }) {
+  let activeCircles = circles.filter(circle => timestamp - circle.start < circle.delay + laserEyeDuration)
+  let { context } = configureCanvas2D({ canvas, height: height + overflow * 2, width: width + overflow * 2 })
+
+  if (context) {
+    context.clearRect(0, 0, width + overflow * 2, height + overflow * 2)
+    context.save()
+    context.translate(overflow, overflow)
+    context.strokeStyle = laserEyeColor
+
+    activeCircles.forEach(circle => {
+      let draw = getLaserEyeDraw(circle, timestamp)
+      if (draw.strokeWidth <= 0 || draw.strokeOpacity <= 0) return
+
+      context.globalAlpha = draw.strokeOpacity
+      context.lineWidth = draw.strokeWidth
+      context.beginPath()
+      context.arc(draw.cx, draw.cy, draw.radius, 0, Math.PI * 2)
+      context.stroke()
+    })
+
+    context.globalAlpha = 1
+    context.restore()
+  }
+
+  return { circles: activeCircles, hasActive: activeCircles.length > 0 }
+}

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -4,6 +4,7 @@ import { configureCanvas2D } from "svelte-lib/functions/canvas"
 const finalRotation = Math.PI / 4
 const finalStrokeWidth = 0.3
 const initialStrokeWidth = 0.075
+const maxStrokePixelRatio = 2
 const timingTolerance = 0.001
 const transitionHiddenHoldDuration = 300
 
@@ -35,6 +36,10 @@ function getCellPixelIndex({ cellPixelIndexes, columnCount, rowCount, x, y }) {
   return cellPixelIndexes[getCellIndex({ columnCount, x, y })]
 }
 
+function getStrokeWidth(width, geometry) {
+  return width * (geometry.strokeScale ?? 1)
+}
+
 function getPixelDisplay(pixel, geometry) {
   return {
     x: pixel.x * geometry.cellWidth,
@@ -45,7 +50,7 @@ function getPixelDisplay(pixel, geometry) {
     translateX: 0,
     translateY: 0,
     opacity: 1,
-    strokeWidth: initialStrokeWidth
+    strokeWidth: getStrokeWidth(initialStrokeWidth, geometry)
   }
 }
 
@@ -70,7 +75,7 @@ function getActivatedPixelDisplay(pixel, geometry) {
     translateX: rotationTranslation.x,
     translateY: rotationTranslation.y,
     opacity: 0,
-    strokeWidth: finalStrokeWidth
+    strokeWidth: getStrokeWidth(finalStrokeWidth, geometry)
   }
 }
 
@@ -95,7 +100,7 @@ function getActivatingPixelDisplay(pixel, state, geometry, timestamp) {
     translateX: activated.translateX * moveProgress,
     translateY: activated.translateY * moveProgress,
     opacity: 1 - fadeProgress,
-    strokeWidth: finalStrokeWidth
+    strokeWidth: getStrokeWidth(finalStrokeWidth, geometry)
   }
 }
 
@@ -119,7 +124,7 @@ function getDeactivatingPixelDisplay(pixel, state, geometry, timestamp) {
     translateX: activated.translateX * moveProgress,
     translateY: activated.translateY * moveProgress,
     opacity: reverseProgress,
-    strokeWidth: finalStrokeWidth + (initialStrokeWidth - finalStrokeWidth) * strokeProgress
+    strokeWidth: getStrokeWidth(finalStrokeWidth + (initialStrokeWidth - finalStrokeWidth) * strokeProgress, geometry)
   }
 }
 
@@ -367,12 +372,13 @@ export function drawPixelCanvas({ canvas, geometry, pixels, states, timestamp })
   let overflow = geometry.overflow ?? 0
   let canvasHeight = geometry.height + overflow * 2
   let canvasWidth = geometry.width + overflow * 2
-  let { context } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
+  let { context, pixelRatio } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
   if (!context) return false
 
+  let renderGeometry = { ...geometry, strokeScale: Math.min(pixelRatio, maxStrokePixelRatio) / pixelRatio }
   let pixelRenderStates = pixels.map(pixel => ({
     pixel,
-    renderState: getPixelRenderState(pixel, states[pixel.index], geometry, timestamp)
+    renderState: getPixelRenderState(pixel, states[pixel.index], renderGeometry, timestamp)
   }))
 
   context.clearRect(0, 0, canvasWidth, canvasHeight)

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -1,4 +1,4 @@
-import { clamp, easeCubicInOut } from "svelte-lib/functions"
+import { easeCubicInOut, getEasedProgress } from "svelte-lib/functions"
 import { configureCanvas2D } from "svelte-lib/functions/canvas"
 
 const finalRotation = Math.PI / 4
@@ -81,8 +81,20 @@ function getActivatedPixelDisplay(pixel, geometry) {
 
 function getActivatingProgress(state, timestamp) {
   return {
-    moveProgress: easeCubicInOut(clamp((timestamp - state.activationStart - transitionDelay) / transitionDuration)),
-    fadeProgress: easeCubicInOut(clamp((timestamp - state.activationStart - transitionFadeDelay) / transitionDuration))
+    moveProgress: getEasedProgress({
+      delay: transitionDelay,
+      duration: transitionDuration,
+      ease: easeCubicInOut,
+      now: timestamp,
+      start: state.activationStart
+    }),
+    fadeProgress: getEasedProgress({
+      delay: transitionFadeDelay,
+      duration: transitionDuration,
+      ease: easeCubicInOut,
+      now: timestamp,
+      start: state.activationStart
+    })
   }
 }
 
@@ -107,12 +119,20 @@ function getActivatingPixelDisplay(pixel, state, geometry, timestamp) {
 function getDeactivatingPixelDisplay(pixel, state, geometry, timestamp) {
   let normal = getPixelDisplay(pixel, geometry)
   let activated = getActivatedPixelDisplay(pixel, geometry)
-  let reverseProgress = easeCubicInOut(
-    clamp((timestamp - state.deactivationStart - transitionDeactivateDelay) / transitionDuration)
-  )
-  let strokeProgress = easeCubicInOut(
-    clamp((timestamp - state.deactivationStart - transitionDeactivateDelay - transitionDuration) / transitionDuration)
-  )
+  let reverseProgress = getEasedProgress({
+    delay: transitionDeactivateDelay,
+    duration: transitionDuration,
+    ease: easeCubicInOut,
+    now: timestamp,
+    start: state.deactivationStart
+  })
+  let strokeProgress = getEasedProgress({
+    delay: transitionDeactivateDelay + transitionDuration,
+    duration: transitionDuration,
+    ease: easeCubicInOut,
+    now: timestamp,
+    start: state.deactivationStart
+  })
   let moveProgress = 1 - reverseProgress
 
   return {


### PR DESCRIPTION
Replaces the d3-selection/d3-transition laser-eye rendering with Canvas 2D, and consolidates the pixel, laser-eye, and auto-transition animation loops onto svelte-lib's createAnimationLoop helper. Also adds pinch-zoom support and fixes the laser-eye canvas stacking order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added animated laser-eye burst effects with expanding, fading visuals.
  - Improved profile photo pixel animations with smoother activation and deactivation transitions.
  - Added better support for pinch-to-zoom touch interactions.

- **Bug Fixes**
  - Improved animation cleanup when leaving or closing the experience.
  - Enhanced rendering quality across devices with clearer, consistently scaled canvas visuals.
  - Updated toggle label capitalization for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->