### PR TITLE
Scale pixel strokes to cell size and clip overflow at the html element

### DIFF
--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -2,9 +2,8 @@ import { easeCubicInOut, getEasedProgress } from "svelte-lib/functions"
 import { configureCanvas2D } from "svelte-lib/functions/canvas"
 
 const finalRotation = Math.PI / 4
-const finalStrokeWidth = 0.3
-const initialStrokeWidth = 0.075
-const maxStrokePixelRatio = 2
+const finalStrokeCellRatio = 0.032
+const initialStrokeCellRatio = 0.008
 const timingTolerance = 0.001
 const transitionHiddenHoldDuration = 300
 
@@ -36,8 +35,8 @@ function getCellPixelIndex({ cellPixelIndexes, columnCount, rowCount, x, y }) {
   return cellPixelIndexes[getCellIndex({ columnCount, x, y })]
 }
 
-function getStrokeWidth(width, geometry) {
-  return width * (geometry.strokeScale ?? 1)
+function getStrokeWidth(cellRatio, geometry) {
+  return cellRatio * geometry.cellWidth
 }
 
 function getPixelDisplay(pixel, geometry) {
@@ -50,7 +49,7 @@ function getPixelDisplay(pixel, geometry) {
     translateX: 0,
     translateY: 0,
     opacity: 1,
-    strokeWidth: getStrokeWidth(initialStrokeWidth, geometry)
+    strokeWidth: getStrokeWidth(initialStrokeCellRatio, geometry)
   }
 }
 
@@ -75,7 +74,7 @@ function getActivatedPixelDisplay(pixel, geometry) {
     translateX: rotationTranslation.x,
     translateY: rotationTranslation.y,
     opacity: 0,
-    strokeWidth: getStrokeWidth(finalStrokeWidth, geometry)
+    strokeWidth: getStrokeWidth(finalStrokeCellRatio, geometry)
   }
 }
 
@@ -112,7 +111,7 @@ function getActivatingPixelDisplay(pixel, state, geometry, timestamp) {
     translateX: activated.translateX * moveProgress,
     translateY: activated.translateY * moveProgress,
     opacity: 1 - fadeProgress,
-    strokeWidth: getStrokeWidth(finalStrokeWidth, geometry)
+    strokeWidth: getStrokeWidth(finalStrokeCellRatio, geometry)
   }
 }
 
@@ -144,7 +143,10 @@ function getDeactivatingPixelDisplay(pixel, state, geometry, timestamp) {
     translateX: activated.translateX * moveProgress,
     translateY: activated.translateY * moveProgress,
     opacity: reverseProgress,
-    strokeWidth: getStrokeWidth(finalStrokeWidth + (initialStrokeWidth - finalStrokeWidth) * strokeProgress, geometry)
+    strokeWidth: getStrokeWidth(
+      finalStrokeCellRatio + (initialStrokeCellRatio - finalStrokeCellRatio) * strokeProgress,
+      geometry
+    )
   }
 }
 
@@ -392,13 +394,12 @@ export function drawPixelCanvas({ canvas, geometry, pixels, states, timestamp })
   let overflow = geometry.overflow ?? 0
   let canvasHeight = geometry.height + overflow * 2
   let canvasWidth = geometry.width + overflow * 2
-  let { context, pixelRatio } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
+  let { context } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
   if (!context) return false
 
-  let renderGeometry = { ...geometry, strokeScale: Math.min(pixelRatio, maxStrokePixelRatio) / pixelRatio }
   let pixelRenderStates = pixels.map(pixel => ({
     pixel,
-    renderState: getPixelRenderState(pixel, states[pixel.index], renderGeometry, timestamp)
+    renderState: getPixelRenderState(pixel, states[pixel.index], geometry, timestamp)
   }))
 
   context.clearRect(0, 0, canvasWidth, canvasHeight)

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 <slot />
 
 <style>
-  :global(body) {
+  :global(html) {
     overflow-x: clip;
   }
 </style>


### PR DESCRIPTION
Fixes pixel stroke rendering so the grid reads the same weight at every screen size and pixel density, and clips the profile photo's intentional canvas overflow at the correct element.

- Stroke widths are now fractions of the cell size instead of fixed CSS pixels, so the 48x48 grid renders identically on desktop and mobile regardless of portrait display size. Removes the `maxStrokePixelRatio` DPR clamp added for the same bug in a prior release, which didn't fix the mismatch (canvas already applies the device pixel ratio transform, so perceived stroke weight was already density-independent) and instead made high-density phones render noticeably lighter than desktop.
- Moves the standalone app's `overflow-x: clip` from `body` to `html`, since Chrome does not propagate the property from `body` to the viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pixel stroke rendering so line widths remain consistent across different display resolutions and animation states.
  - Updated horizontal overflow handling to provide more reliable page-wide layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
