### PR TITLE
Fix uneven pixel-grid strokes, pinch-zoom overflow, and hollow laser-eye circles

### DIFF
--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -521,7 +521,7 @@
       style:top="{-laserEyeOverflow}px"
       style:width="{displayWidth + laserEyeOverflow * 2}px"
       style:height="{displayHeight + laserEyeOverflow * 2}px"
-      style:z-index={70}
+      style:z-index={60}
       aria-hidden="true"
     ></canvas>
     <canvas
@@ -531,7 +531,7 @@
       style:top="{-canvasOverflow}px"
       style:width="{canvasWidth}px"
       style:height="{canvasHeight}px"
-      style:z-index={60}
+      style:z-index={70}
       aria-hidden="true"
     ></canvas>
   </div>

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -89,6 +89,8 @@
 
   let displayWidth
   let displayHeight
+  let contentWrapper
+  let viewportWidth
   let pixelCanvas
   let laserEyeCanvas
   let pixelStates = createPixelStates(pixelRecords.length)
@@ -143,6 +145,8 @@
           height: displayHeight,
           cellWidth: displayWidth / pixelColumnCount,
           cellHeight: displayHeight / pixelRowCount,
+          columnCount: pixelColumnCount,
+          rowCount: pixelRowCount,
           overflow: Math.max(displayWidth, displayHeight) / 8
         }
       : undefined
@@ -160,6 +164,14 @@
   ].join(":")
   $: isProfileReady = pixelCanvas && laserEyeCanvas && geometry
   $: laserEyeOverflow = displayWidth ? displayWidth * laserEyeRadiusScale : 0
+  $: viewportGap = displayWidth ? getViewportGap(contentWrapper, viewportWidth) : 0
+
+  function getViewportGap(element, width) {
+    let bounds = element?.parentElement?.getBoundingClientRect()
+    if (!bounds || !width) return 0
+
+    return Math.max(0, Math.min(bounds.left, width - bounds.right))
+  }
 
   function renderPixels(timestamp) {
     if (!pixelCanvas || !geometry) return false
@@ -493,7 +505,14 @@
   })
 </script>
 
-<div class="mb-8 flex flex-col items-center">
+<svelte:window bind:innerWidth={viewportWidth} />
+
+<div
+  class="mb-8 flex flex-col items-center overflow-x-clip"
+  bind:this={contentWrapper}
+  style:margin-inline="{-viewportGap}px"
+  style:padding-inline="{viewportGap}px"
+>
   <div
     class="relative w-fit max-w-md"
     class:non-reactive={isAutoTransition}

--- a/frontend/src/lib/laserEye.js
+++ b/frontend/src/lib/laserEye.js
@@ -52,6 +52,7 @@ export function drawLaserEyeCanvas({ canvas, circles, height, overflow = 0, time
     context.clearRect(0, 0, width + overflow * 2, height + overflow * 2)
     context.save()
     context.translate(overflow, overflow)
+    context.fillStyle = laserEyeColor
     context.strokeStyle = laserEyeColor
 
     activeCircles.forEach(circle => {
@@ -59,8 +60,16 @@ export function drawLaserEyeCanvas({ canvas, circles, height, overflow = 0, time
       if (draw.strokeWidth <= 0 || draw.strokeOpacity <= 0) return
 
       context.globalAlpha = draw.strokeOpacity
-      context.lineWidth = draw.strokeWidth
       context.beginPath()
+
+      if (draw.radius * 2 <= draw.strokeWidth) {
+        context.arc(draw.cx, draw.cy, draw.radius + draw.strokeWidth / 2, 0, Math.PI * 2)
+        context.fill()
+
+        return
+      }
+
+      context.lineWidth = draw.strokeWidth
       context.arc(draw.cx, draw.cy, draw.radius, 0, Math.PI * 2)
       context.stroke()
     })

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -2,8 +2,8 @@ import { easeCubicInOut, getEasedProgress } from "svelte-lib/functions"
 import { configureCanvas2D } from "svelte-lib/functions/canvas"
 
 const finalRotation = Math.PI / 4
-const finalStrokeCellRatio = 0.032
-const initialStrokeCellRatio = 0.008
+const finalStrokeWidth = 0.3
+const separatorAlpha = 0.31
 const timingTolerance = 0.001
 const transitionHiddenHoldDuration = 300
 
@@ -35,21 +35,26 @@ function getCellPixelIndex({ cellPixelIndexes, columnCount, rowCount, x, y }) {
   return cellPixelIndexes[getCellIndex({ columnCount, x, y })]
 }
 
-function getStrokeWidth(cellRatio, geometry) {
-  return cellRatio * geometry.cellWidth
+function snapToDevicePixel(value, geometry) {
+  let overflow = geometry.overflow ?? 0
+  let pixelRatio = geometry.pixelRatio ?? 1
+
+  return Math.round((value + overflow) * pixelRatio) / pixelRatio - overflow
 }
 
 function getPixelDisplay(pixel, geometry) {
+  let x = snapToDevicePixel(pixel.x * geometry.cellWidth, geometry)
+  let y = snapToDevicePixel(pixel.y * geometry.cellHeight, geometry)
+
   return {
-    x: pixel.x * geometry.cellWidth,
-    y: pixel.y * geometry.cellHeight,
-    width: geometry.cellWidth,
-    height: geometry.cellHeight,
+    x,
+    y,
+    width: snapToDevicePixel((pixel.x + 1) * geometry.cellWidth, geometry) - x,
+    height: snapToDevicePixel((pixel.y + 1) * geometry.cellHeight, geometry) - y,
     rotation: 0,
     translateX: 0,
     translateY: 0,
-    opacity: 1,
-    strokeWidth: getStrokeWidth(initialStrokeCellRatio, geometry)
+    opacity: 1
   }
 }
 
@@ -74,7 +79,7 @@ function getActivatedPixelDisplay(pixel, geometry) {
     translateX: rotationTranslation.x,
     translateY: rotationTranslation.y,
     opacity: 0,
-    strokeWidth: getStrokeWidth(finalStrokeCellRatio, geometry)
+    strokeWidth: finalStrokeWidth
   }
 }
 
@@ -111,7 +116,7 @@ function getActivatingPixelDisplay(pixel, state, geometry, timestamp) {
     translateX: activated.translateX * moveProgress,
     translateY: activated.translateY * moveProgress,
     opacity: 1 - fadeProgress,
-    strokeWidth: getStrokeWidth(finalStrokeCellRatio, geometry)
+    strokeWidth: finalStrokeWidth
   }
 }
 
@@ -120,13 +125,6 @@ function getDeactivatingPixelDisplay(pixel, state, geometry, timestamp) {
   let activated = getActivatedPixelDisplay(pixel, geometry)
   let reverseProgress = getEasedProgress({
     delay: transitionDeactivateDelay,
-    duration: transitionDuration,
-    ease: easeCubicInOut,
-    now: timestamp,
-    start: state.deactivationStart
-  })
-  let strokeProgress = getEasedProgress({
-    delay: transitionDeactivateDelay + transitionDuration,
     duration: transitionDuration,
     ease: easeCubicInOut,
     now: timestamp,
@@ -143,10 +141,7 @@ function getDeactivatingPixelDisplay(pixel, state, geometry, timestamp) {
     translateX: activated.translateX * moveProgress,
     translateY: activated.translateY * moveProgress,
     opacity: reverseProgress,
-    strokeWidth: getStrokeWidth(
-      finalStrokeCellRatio + (initialStrokeCellRatio - finalStrokeCellRatio) * strokeProgress,
-      geometry
-    )
+    strokeWidth: finalStrokeWidth
   }
 }
 
@@ -178,16 +173,10 @@ function fillPixel(context, pixel, renderState) {
 }
 
 function strokePixel(context, renderState) {
-  if (renderState.opacity <= 0) return
+  if (renderState.opacity <= 0 || !renderState.rotation) return
 
   context.globalAlpha = renderState.opacity
   context.lineWidth = renderState.strokeWidth
-
-  if (!renderState.rotation) {
-    context.strokeRect(renderState.x, renderState.y, renderState.width, renderState.height)
-
-    return
-  }
 
   context.save()
   context.translate(renderState.translateX, renderState.translateY)
@@ -390,16 +379,83 @@ export function advanceAutoTransitionPath({ path, now, setDelay = transitionDura
   return true
 }
 
+function drawPixelSeparators(context, pixelRenderStates, geometry) {
+  let { cellHeight, cellWidth, columnCount, rowCount } = geometry
+  let overflow = geometry.overflow ?? 0
+  let pixelRatio = geometry.pixelRatio ?? 1
+  let opacities = new Float64Array(columnCount * rowCount)
+
+  pixelRenderStates.forEach(({ pixel, renderState }) => {
+    if (!renderState.rotation) opacities[pixel.y * columnCount + pixel.x] = renderState.opacity
+  })
+
+  let opacityAt = (column, row) =>
+    column < 0 || row < 0 || column >= columnCount || row >= rowCount ? 0 : opacities[row * columnCount + column]
+  let devicePosition = (index, cellSize) => Math.round((index * cellSize + overflow) * pixelRatio)
+
+  context.save()
+  context.setTransform(1, 0, 0, 1, 0, 0)
+  context.fillStyle = "white"
+
+  let drawRuns = (lineCount, segmentCount, alphaAt, drawRun) => {
+    for (let line = 0; line <= lineCount; line++) {
+      let runStart = 0
+      let runAlpha = 0
+
+      for (let segment = 0; segment <= segmentCount; segment++) {
+        let alpha = segment < segmentCount ? alphaAt(line, segment) : -1
+        if (alpha == runAlpha) continue
+
+        if (runAlpha > 0) {
+          context.globalAlpha = runAlpha * separatorAlpha
+          drawRun(line, runStart, segment)
+        }
+
+        runStart = segment
+        runAlpha = alpha
+      }
+    }
+  }
+
+  drawRuns(
+    columnCount,
+    rowCount,
+    (column, row) => Math.max(opacityAt(column - 1, row), opacityAt(column, row)),
+    (column, from, to) =>
+      context.fillRect(
+        devicePosition(column, cellWidth),
+        devicePosition(from, cellHeight),
+        1,
+        devicePosition(to, cellHeight) - devicePosition(from, cellHeight)
+      )
+  )
+  drawRuns(
+    rowCount,
+    columnCount,
+    (row, column) => Math.max(opacityAt(column, row - 1), opacityAt(column, row)),
+    (row, from, to) =>
+      context.fillRect(
+        devicePosition(from, cellWidth),
+        devicePosition(row, cellHeight),
+        devicePosition(to, cellWidth) - devicePosition(from, cellWidth),
+        1
+      )
+  )
+
+  context.restore()
+}
+
 export function drawPixelCanvas({ canvas, geometry, pixels, states, timestamp }) {
   let overflow = geometry.overflow ?? 0
   let canvasHeight = geometry.height + overflow * 2
   let canvasWidth = geometry.width + overflow * 2
-  let { context } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
+  let { context, pixelRatio } = configureCanvas2D({ canvas, height: canvasHeight, width: canvasWidth })
   if (!context) return false
 
+  let renderGeometry = { ...geometry, pixelRatio }
   let pixelRenderStates = pixels.map(pixel => ({
     pixel,
-    renderState: getPixelRenderState(pixel, states[pixel.index], geometry, timestamp)
+    renderState: getPixelRenderState(pixel, states[pixel.index], renderGeometry, timestamp)
   }))
 
   context.clearRect(0, 0, canvasWidth, canvasHeight)
@@ -407,6 +463,7 @@ export function drawPixelCanvas({ canvas, geometry, pixels, states, timestamp })
   context.translate(overflow, overflow)
   context.strokeStyle = "white"
   pixelRenderStates.forEach(({ pixel, renderState }) => fillPixel(context, pixel, renderState))
+  drawPixelSeparators(context, pixelRenderStates, renderGeometry)
   pixelRenderStates.forEach(({ renderState }) => strokePixel(context, renderState))
   context.restore()
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,9 +7,3 @@
 </script>
 
 <slot />
-
-<style>
-  :global(html) {
-    overflow-x: clip;
-  }
-</style>


### PR DESCRIPTION
Fixes three profile-photo rendering bugs: uneven pixel-grid strokes on high-density mobile screens, pinch-zoom letting the page zoom out past the viewport width, and hollow (instead of filled) laser-eye circles while they rest on the eyes. Also corrects the laser-eye/pixel-grid stacking order.

- **Pixel grid strokes** were sub-device-pixel lines on a fractional cell pitch, with every interior boundary stroked twice (once by each touching pixel). Safari rasterizes sub-pixel hairlines unevenly, so separators measured 0 to 1.33 device px on iOS (63% variation) despite rendering evenly in Chrome. Cell rects now snap to whole device pixels and each boundary is drawn exactly once, at the weight the original 0.075 CSS px hairline rendered at on a 2x display — measured in-app at 0.311px with 2.2% variation (residual 8-bit quantization).
- **Pinch-zoom overflow**: `overflow-x: clip` on the root element suppressed scrolling but left the overflow in the document's scroll width, which is what Safari uses to size minimum pinch-zoom — so a 393px phone could still zoom out to the full 650px document. The app now clips its own canvas overflow at the viewport instead, on a wrapper widened to match; both now-dead root-level clip rules are removed.
- **Laser-eye circles**: each circle starts at radius 0.25 with a 7.5 stroke, so its inner edge falls past the center. Canvas draws that as a thin ring rather than a solid dot. Circles whose diameter is within their stroke width are now filled to the stroke's outer edge instead of stroked, so the dot opens into a ring with no visual jump.
- **Stacking order**: laser vision now renders below the pixel grid and above the base photo, reversing 66fcb54 which had inverted this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile display alignment across different viewport widths.
  * Sharpened pixel rendering for clearer edges and more consistent spacing.
  * Added cleaner separators between adjacent pixels based on their visibility.
  * Corrected canvas layering so profile pixels display properly over laser effects.
  * Improved laser-eye rendering, with small circles now appearing as solid colored disks while larger circles remain outlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
