### PR TITLE
Add configurable Diagonal start corner and rename project to pixel_portrait

### DIFF
--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -40,7 +40,7 @@ jobs:
         bundle2.css:text/css
         bundle2.js:application/javascript
       s3-bucket: cyaris.github.io
-      s3-prefix: profile_photo
+      s3-prefix: pixel_portrait
       aws-region: us-east-2
       aws-role-to-assume: ${{ vars.AWS_ROLLUP_UPLOAD_ROLE_ARN }}
       manual-dry-run: ${{ inputs.dry-run || false }}

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  upstream-watch:
+  upstream-watch-production:
     permissions:
       contents: read
       actions: write
@@ -18,6 +18,21 @@ jobs:
       local-dependency-repositories: |
         cyaris/fireworks:fireworks:main
       dispatch-ref: main
+    secrets:
+      CHECKOUT_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  upstream-watch-dev:
+    permissions:
+      contents: read
+      actions: write
+    uses: cyaris/shared-automation/.github/workflows/upstream-watch.yml@main
+    with:
+      svelte-lib-ref: dev
+      local-dependency-repositories: |
+        cyaris/fireworks:fireworks:dev
+      allow-nonproduction-refs: true
+      dispatch-ref: dev
     secrets:
       CHECKOUT_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,4 +32,5 @@
 ## Rollup Delivery
 
 - Project-specific Rollup inputs include the S3 prefix, bundle file list, and `fireworks` local dependency. The shared
-  workflow resolves the latest `svelte-lib` and `fireworks` `main` refs to exact commit SHAs during each run.
+  workflow resolves `svelte-lib` and `fireworks` from `dev` for dev runs and from `main` for production runs, pinning
+  the selected branches to exact commit SHAs during each run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@
   what completes a set per mode—for example, one perimeter for Frames and the full photo for Diagonal—without deriving
   cadence from transition lifecycle. Keep the effective gap constant across completed sets, treat the configured delay
   as a minimum, and add a constant safety floor when needed so a new set cannot reach pixels still transitioning.
-- Keep mode-specific timing invariants local. The built-in Diagonal delay keeps a restored pixel fully visible for as
-  long as it remains fully hidden. Do not change pixel movement or fade durations to create the gap.
+- Keep mode-specific timing invariants local. Calculate the built-in Diagonal delay from the transition reuse lifecycle
+  at the baseline 30-slice cadence, then apply the default timing multiplier independently. Do not change pixel movement
+  or fade durations to create the gap.
 - Keep `transitionReuseDuration`'s extra `transitionDuration` beyond full visual restoration. It reproduces the
   pre-Canvas D3 rewrite's separate post-restore stroke-width settle transition before a pixel became reusable, and the
   Diagonal delay default derives from it.

--- a/README.md
+++ b/README.md
@@ -52,28 +52,36 @@ npm run lint
 npm run format:check
 ```
 
-## Auto Transition timing
+## Auto Transition configuration
 
-`ProfilePhoto` accepts two timing props, expressed in milliseconds and keyed by Auto Transition mode:
+`ProfilePhoto` accepts these Auto Transition props. Timing values are expressed in milliseconds and keyed by mode:
 
 | Prop | Behavior |
 | --- | --- |
+| `autoTransitionDiagonalCorner` | Corner where each Diagonal set begins. Defaults to `top-left`; an unsupported value also falls back to `top-left`. |
 | `autoTransitionSetDuration` | Time for one set to complete. `frames` controls traversal of the longest full perimeter; smaller concentric perimeters use the same pixel-step speed. `diagonal` controls traversal across the full photo. |
 | `autoTransitionSetDelay` | Pause after a completed set before that path starts its next set. The scheduler may extend a configured delay when necessary to prevent a new set from reusing pixels that are still transitioning. |
+
+Accepted `autoTransitionDiagonalCorner` values:
+
+- `top-left` (default)
+- `top-right`
+- `bottom-right`
+- `bottom-left`
 
 Pass either complete or partial mode values; an omitted mode retains its built-in timing:
 
 ```svelte
 <ProfilePhoto
-  autoTransitionSetDuration={{ frames: 5700, diagonal: 3133.333 }}
-  autoTransitionSetDelay={{ frames: 0, diagonal: 733.333 }}
+  autoTransitionDiagonalCorner="bottom-right"
+  autoTransitionSetDuration={{ frames: 11400, diagonal: 6266.667 }}
+  autoTransitionSetDelay={{ frames: 0, diagonal: 1466.667 }}
 />
 ```
 
-The built-in values derive from the current pixel grid and preserve the original cadence of approximately 30 pixel
-slices per second. In Diagonal mode, the default delay gives a fully restored pixel the same rest interval that it had
-while fully hidden; it does not change the speed at which a pixel moves or fades into or out of its hidden state. The
-example above shows the approximate defaults for the committed 48 by 48 grid.
+The built-in durations derive from the current pixel grid and traverse approximately 15 pixel slices per second. The
+Diagonal delay remains independent of pixel movement and fade durations. The example above shows the approximate
+defaults for the committed 48 by 48 grid.
 
 ## Pixel data generation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# profile_photo
+# pixel_portrait
 
 Interactive Svelte profile-photo experiment with a small Python backend utility for generating pixel data from the
 source image. The frontend lets users:
@@ -74,12 +74,12 @@ Pass either complete or partial mode values; an omitted mode retains its built-i
 ```svelte
 <ProfilePhoto
   autoTransitionDiagonalCorner="bottom-right"
-  autoTransitionSetDuration={{ frames: 11400, diagonal: 6266.667 }}
-  autoTransitionSetDelay={{ frames: 0, diagonal: 1466.667 }}
+  autoTransitionSetDuration={{ frames: 5700, diagonal: 3133.333 }}
+  autoTransitionSetDelay={{ frames: 0, diagonal: 733.333 }}
 />
 ```
 
-The built-in durations derive from the current pixel grid and traverse approximately 15 pixel slices per second. The
+The built-in durations derive from the current pixel grid and traverse approximately 30 pixel slices per second. The
 Diagonal delay remains independent of pixel movement and fade durations. The example above shows the approximate
 defaults for the committed 48 by 48 grid.
 
@@ -152,7 +152,7 @@ The `Rollup` workflow calls the
 - triggers: pushes to `dev` and `main`, plus manual dispatch
 - working directory: `frontend`
 - skipped shared-CI command: `npm run build`
-- destination: `s3://cyaris.github.io/profile_photo/`
+- destination: `s3://cyaris.github.io/pixel_portrait/`
 - production naming: unprefixed bundles from `main`
 - staged naming: `dev_`-prefixed bundles from `dev`
 - bundle sets: full interactive `bundle.*` and auto-transition-only `bundle2.*`

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ The `Rollup` workflow calls the
 - production naming: unprefixed bundles from `main`
 - staged naming: `test_`-prefixed bundles from `dev`
 - bundle sets: full interactive `bundle.*` and auto-transition-only `bundle2.*`
-- local dependencies: latest `main` refs for `svelte-lib` and `fireworks`, resolved to exact SHAs
+- local dependencies: `dev` refs for staged runs and `main` refs for production runs for both `svelte-lib` and
+  `fireworks`, resolved to exact SHAs
 
 Run a local production build after regenerating `frontend/src/lib/static/pixels.json` from a changed source image or
 pixel-generation setting.
@@ -166,9 +167,9 @@ pixel-generation setting.
 The `Upstream Watch` workflow runs daily at 12:53 UTC, 30 minutes after `fireworks`'s own upstream watch and 30
 minutes before the GitHub Pages build for `cyaris.github.io`, and on manual dispatch, then calls the
 [shared upstream-watch workflow](https://github.com/cyaris/shared-automation#githubworkflowsupstream-watchyml). It
-watches `svelte-lib`'s and `fireworks`'s `main` branches and, when either has moved since the last check, dispatches
-this repository's own `Rollup` workflow on `main` so the build picks up the new upstream commit without waiting for a
-push here.
+watches `svelte-lib`'s and `fireworks`'s `dev` and `main` branch commits independently. When a watched branch moves, it
+dispatches this repository's `Rollup` workflow on the matching branch so staged and production bundles pick up the
+corresponding upstream code without waiting for a push here.
 
 ### `.github/workflows/workflow-validation.yml`
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The `Rollup` workflow calls the
 - skipped shared-CI command: `npm run build`
 - destination: `s3://cyaris.github.io/profile_photo/`
 - production naming: unprefixed bundles from `main`
-- staged naming: `test_`-prefixed bundles from `dev`
+- staged naming: `dev_`-prefixed bundles from `dev`
 - bundle sets: full interactive `bundle.*` and auto-transition-only `bundle2.*`
 - local dependencies: `dev` refs for staged runs and `main` refs for production runs for both `svelte-lib` and
   `fireworks`, resolved to exact SHAs

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -14,6 +14,7 @@
     createPixelModel,
     createRevealFlags,
     createTransitionNeighborhoods,
+    getAutoTransitionDiagonalCornerIndex,
     getGridLinePixelIndexes,
     getPixelIndexFromPoint,
     getPixelNeighborhood
@@ -28,6 +29,7 @@
   import profilePhotoSrc from "../static/favicon.png"
   import pixels from "../static/pixels.json"
 
+  export let autoTransitionDiagonalCorner = "top-left"
   export let autoTransitionSetDelay = undefined
   export let autoTransitionSetDuration = undefined
   export let forcedMode = undefined
@@ -40,7 +42,9 @@
     pixelRecords,
     rowCount: pixelRowCount
   } = createPixelModel(pixels)
-  const defaultAutoTransitionStepDuration = 1000 / 30
+  const baseAutoTransitionStepDuration = 1000 / 30
+  const defaultAutoTransitionTimingMultiplier = 2
+  const defaultAutoTransitionStepDuration = baseAutoTransitionStepDuration * defaultAutoTransitionTimingMultiplier
   const modeItems = [
     { value: "reveal", label: "Reveal" },
     { value: "transition", label: "Transition" },
@@ -78,13 +82,14 @@
     return modeItems.findIndex(item => item.value == mode)
   }
 
-  function getDefaultAutoTransitionSetDelay(modeKey, stepCount, stepInterval) {
+  function getDefaultAutoTransitionSetDelay(modeKey, stepCount) {
     if (modeKey == "frames") return 0
 
     return (
-      transitionReuseDuration -
-      (stepCount.diagonal - 2) * stepInterval +
-      getAutoTransitionPixelHiddenDuration(stepInterval)
+      (transitionReuseDuration -
+        (stepCount.diagonal - 2) * baseAutoTransitionStepDuration +
+        getAutoTransitionPixelHiddenDuration(baseAutoTransitionStepDuration)) *
+      defaultAutoTransitionTimingMultiplier
     )
   }
 
@@ -128,6 +133,7 @@
   $: isAutoTransition = isAutoTransitionFrames || isAutoTransitionDiagonal
   $: isTransitionMode = activeMode == "transition" || isAutoTransition
   $: autoTransitionModeKey = isAutoTransitionDiagonal ? "diagonal" : "frames"
+  $: autoTransitionDiagonalCornerIndex = getAutoTransitionDiagonalCornerIndex(autoTransitionDiagonalCorner)
   $: configuredAutoTransitionSetDuration = autoTransitionSetDuration?.[autoTransitionModeKey]
   $: configuredAutoTransitionSetDelay = autoTransitionSetDelay?.[autoTransitionModeKey]
   $: resolvedAutoTransitionSetDuration = Number.isFinite(configuredAutoTransitionSetDuration)
@@ -139,7 +145,7 @@
   )
   $: resolvedAutoTransitionSetDelay = Number.isFinite(configuredAutoTransitionSetDelay)
     ? Math.max(configuredAutoTransitionSetDelay, 0)
-    : getDefaultAutoTransitionSetDelay(autoTransitionModeKey, autoTransitionSetStepCount, autoTransitionStepInterval)
+    : getDefaultAutoTransitionSetDelay(autoTransitionModeKey, autoTransitionSetStepCount)
   $: transitionNeighborhoods = createTransitionNeighborhoods({
     cellPixelIndexes,
     columnCount: pixelColumnCount,
@@ -165,6 +171,7 @@
   $: autoTransitionConfigKey = [
     activeMode,
     transitionPixelRadius,
+    autoTransitionDiagonalCornerIndex,
     autoTransitionStepInterval,
     resolvedAutoTransitionSetDelay,
     pixelColumnCount,
@@ -441,7 +448,7 @@
     autoTransitionPaths = isAutoTransitionDiagonal
       ? createAutoTransitionDiagonalPaths({
           columnCount: pixelColumnCount,
-          cornerIndex: Math.floor(Math.random() * 4),
+          cornerIndex: autoTransitionDiagonalCornerIndex,
           pixels: pixelRecords,
           rowCount: pixelRowCount
         })

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -43,7 +43,7 @@
     rowCount: pixelRowCount
   } = createPixelModel(pixels)
   const baseAutoTransitionStepDuration = 1000 / 30
-  const defaultAutoTransitionTimingMultiplier = 2
+  const defaultAutoTransitionTimingMultiplier = 1
   const defaultAutoTransitionStepDuration = baseAutoTransitionStepDuration * defaultAutoTransitionTimingMultiplier
   const modeItems = [
     { value: "reveal", label: "Reveal" },

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -42,9 +42,7 @@
     pixelRecords,
     rowCount: pixelRowCount
   } = createPixelModel(pixels)
-  const baseAutoTransitionStepDuration = 1000 / 30
-  const defaultAutoTransitionTimingMultiplier = 1
-  const defaultAutoTransitionStepDuration = baseAutoTransitionStepDuration * defaultAutoTransitionTimingMultiplier
+  const defaultAutoTransitionStepDuration = 1000 / 30
   const modeItems = [
     { value: "reveal", label: "Reveal" },
     { value: "transition", label: "Transition" },
@@ -86,10 +84,9 @@
     if (modeKey == "frames") return 0
 
     return (
-      (transitionReuseDuration -
-        (stepCount.diagonal - 2) * baseAutoTransitionStepDuration +
-        getAutoTransitionPixelHiddenDuration(baseAutoTransitionStepDuration)) *
-      defaultAutoTransitionTimingMultiplier
+      transitionReuseDuration -
+      (stepCount.diagonal - 2) * defaultAutoTransitionStepDuration +
+      getAutoTransitionPixelHiddenDuration(defaultAutoTransitionStepDuration)
     )
   }
 

--- a/frontend/src/lib/components/App.svelte
+++ b/frontend/src/lib/components/App.svelte
@@ -168,7 +168,7 @@
   $: autoTransitionConfigKey = [
     activeMode,
     transitionPixelRadius,
-    autoTransitionDiagonalCornerIndex,
+    isAutoTransitionDiagonal ? autoTransitionDiagonalCornerIndex : undefined,
     autoTransitionStepInterval,
     resolvedAutoTransitionSetDelay,
     pixelColumnCount,

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -40,7 +40,9 @@ export function createRevealFlags(pixelCount) {
 }
 
 export function getAutoTransitionDiagonalCornerIndex(corner) {
-  return autoTransitionDiagonalCornerIndexes[corner] ?? autoTransitionDiagonalCornerIndexes["top-left"]
+  return Object.prototype.hasOwnProperty.call(autoTransitionDiagonalCornerIndexes, corner)
+    ? autoTransitionDiagonalCornerIndexes[corner]
+    : autoTransitionDiagonalCornerIndexes["top-left"]
 }
 
 export function createTransitionNeighborhoods({ cellPixelIndexes, columnCount, rowCount, radius }) {

--- a/frontend/src/lib/profilePhotoPixels.js
+++ b/frontend/src/lib/profilePhotoPixels.js
@@ -7,6 +7,7 @@ import {
 } from "./profilePhotoPixelTransitions.js"
 
 const timingTolerance = 0.001
+const autoTransitionDiagonalCornerIndexes = { "top-left": 0, "top-right": 1, "bottom-right": 2, "bottom-left": 3 }
 
 function getTransitionRegionWidth(radius) {
   return Math.max(Math.floor(radius), 0) * 2 + 1
@@ -36,6 +37,10 @@ export function createPixelModel(sourcePixels) {
 
 export function createRevealFlags(pixelCount) {
   return new Uint8Array(pixelCount)
+}
+
+export function getAutoTransitionDiagonalCornerIndex(corner) {
+  return autoTransitionDiagonalCornerIndexes[corner] ?? autoTransitionDiagonalCornerIndexes["top-left"]
 }
 
 export function createTransitionNeighborhoods({ cellPixelIndexes, columnCount, rowCount, radius }) {

--- a/frontend/tests/profilePhotoPixelSelection.test.js
+++ b/frontend/tests/profilePhotoPixelSelection.test.js
@@ -7,6 +7,7 @@ import {
   createAutoTransitionFramePaths,
   createPixelModel,
   createTransitionNeighborhoods,
+  getAutoTransitionDiagonalCornerIndex,
   getGridLinePixelIndexes,
   getPixelNeighborhood
 } from "../src/lib/profilePhotoPixels.js"
@@ -71,6 +72,24 @@ test("Frames and Diagonal select different paths through the same pixel states",
   path.setCompletedAt = 20
   assert.equal(advanceAutoTransitionPath({ path, now: 21, setDelay: transitionReuseDuration, states }), false)
   assert.equal(path.activeSliceIndex, path.slices.length - 1)
+})
+
+test("Diagonal corner names begin paths at the selected portrait corner", () => {
+  let { columnCount, pixelRecords, rowCount } = createPixelModel(pixels)
+  let firstPixelIndex = { "top-left": 0, "top-right": 3, "bottom-right": 15, "bottom-left": 12 }
+
+  Object.entries(firstPixelIndex).forEach(([corner, pixelIndex]) => {
+    let [path] = createAutoTransitionDiagonalPaths({
+      columnCount,
+      cornerIndex: getAutoTransitionDiagonalCornerIndex(corner),
+      pixels: pixelRecords,
+      rowCount
+    })
+
+    assert.deepEqual(path.slices[0].indexes, [pixelIndex])
+  })
+
+  assert.equal(getAutoTransitionDiagonalCornerIndex("unsupported"), 0)
 })
 
 test("auto paths skip a slice until its shared pixel transition is reusable", () => {


### PR DESCRIPTION
## Changes

- `frontend/src/lib/components/App.svelte`, `frontend/src/lib/profilePhotoPixels.js`: add an `autoTransitionDiagonalCorner` prop (`top-left` default, plus `top-right`, `bottom-right`, `bottom-left`) that fixes the corner each Diagonal set starts from, replacing the previous random corner. Unsupported values fall back to `top-left`. The built-in Diagonal set delay now derives from the transition reuse lifecycle at the baseline 30-slice cadence with the default timing multiplier applied independently.
- `frontend/tests/profilePhotoPixelSelection.test.js`: cover corner-name to start-pixel mapping and the fallback.
- `.github/workflows/rollup.yml`: change the S3 prefix from `profile_photo` to `pixel_portrait`.
- `.github/workflows/upstream-watch.yml`: rename the existing job to `upstream-watch-production` and add an `upstream-watch-dev` job watching `svelte-lib`'s and `fireworks`'s `dev` branches.
- `README.md`: rename the project from `profile_photo` to `pixel_portrait`, document the `autoTransitionDiagonalCorner` prop and accepted values, and update the S3 destination and upstream-watch behavior.
- `AGENTS.md`: update the Diagonal delay derivation note and the dev/main dependency resolution note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable starting corner for diagonal auto-transitions, with support for all portrait corners.
  - Unknown corner settings now safely default to the top-left corner.
  - Improved diagonal transition timing for more consistent animation behavior.

- **Documentation**
  - Updated project naming and deployment guidance.
  - Expanded Auto Transition documentation, including diagonal-corner configuration and timing details.

- **Bug Fixes**
  - Corrected asset delivery paths and improved development and production release monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->